### PR TITLE
Remove static procedure declaration from .h file

### DIFF
--- a/Inc/ssd1306.h
+++ b/Inc/ssd1306.h
@@ -59,6 +59,4 @@ char ssd1306_WriteChar(char ch, FontDef Font, SSD1306_COLOR color);
 char ssd1306_WriteString(char* str, FontDef Font, SSD1306_COLOR color);
 void ssd1306_SetCursor(uint8_t x, uint8_t y);
 
-static void ssd1306_WriteCommand(uint8_t command);
-
 #endif


### PR DESCRIPTION
This line is redundant. When compiling with -Wall flag it generates warning:
```
In file included from Src/main.c:7:0:
ssd1306/ssd1306.h:62:13: warning: 'ssd1306_WriteCommand' declared 'static' but never defined [-Wunused-function]
 static void ssd1306_WriteCommand(uint8_t command);
             ^~~~~~~~~~~~~~~~~~~~
```