### PR TITLE
Add support for 128x32 oled screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ ssd1306_WriteString("4ilo", Font_11x18, White);
 ssd1306_UpdateScreen(&hi2c1);
 
 ```
+
+### 128x32 example
+The library can be used with different screen sizes by redefining the `SSD1306_WIDTH` and `SSD_1306_HEIGHT` defines.
+Some smaller screens might be wired with interlacing, if you encounter issues related to interlacing defining `SSD1306_COM_LR_DISABLE_REMAP` will configure the controller to support this feature.
+
+```
+make EXTRA_CFLAGS="-DSSD1306_HEIGHT=32 -DSSD1306_COM_LR_DISABLE_REMAP"
+```

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ ssd1306_UpdateScreen(&hi2c1);
 
 ### 128x32 example
 The library can be used with different screen sizes by redefining the `SSD1306_WIDTH` and `SSD_1306_HEIGHT` defines.
-Some smaller screens might be wired with interlacing, if you encounter issues related to interlacing defining `SSD1306_COM_LR_DISABLE_REMAP` will configure the controller to support this feature.
+Some smaller screens might be wired with interlacing, if you encounter issues related to interlacing defining `SSD1306_COM_LR_REMAP` will configure the controller to support this feature.
 
 ```
-make EXTRA_CFLAGS="-DSSD1306_HEIGHT=32 -DSSD1306_COM_LR_DISABLE_REMAP"
+make EXTRA_CFLAGS="-DSSD1306_HEIGHT=32 -DSSD1306_COM_LR_REMAP"
 ```

--- a/example/Makefile
+++ b/example/Makefile
@@ -128,7 +128,7 @@ C_INCLUDES =  \
 # compile gcc flags
 ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
 
-CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) $(EXTRA_FLAGS) -Wall -fdata-sections -ffunction-sections
+CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) $(EXTRA_CFLAGS) -Wall -fdata-sections -ffunction-sections
 
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2

--- a/lib/ssd1306.c
+++ b/lib/ssd1306.c
@@ -52,7 +52,7 @@ uint8_t ssd1306_Init(I2C_HandleTypeDef *hi2c)
     status += ssd1306_WriteCommand(hi2c, 0x22);
 
     status += ssd1306_WriteCommand(hi2c, 0xDA);   // Set com pins hardware configuration
-#ifndef SSD1306_COM_LR_REMAP
+#ifdef SSD1306_COM_LR_REMAP
     status += ssd1306_WriteCommand(hi2c, 0x32);   // Enable COM left/right remap
 #else
     status += ssd1306_WriteCommand(hi2c, 0x12);   // Do not use COM left/right remap

--- a/lib/ssd1306.c
+++ b/lib/ssd1306.c
@@ -39,8 +39,10 @@ uint8_t ssd1306_Init(I2C_HandleTypeDef *hi2c)
     status += ssd1306_WriteCommand(hi2c, 0xFF);
     status += ssd1306_WriteCommand(hi2c, 0xA1);   // Set segment re-map 0 to 127
     status += ssd1306_WriteCommand(hi2c, 0xA6);   // Set normal display
+
     status += ssd1306_WriteCommand(hi2c, 0xA8);   // Set multiplex ratio(1 to 64)
-    status += ssd1306_WriteCommand(hi2c, 0x3F);
+    status += ssd1306_WriteCommand(hi2c, SSD1306_HEIGHT - 1);
+
     status += ssd1306_WriteCommand(hi2c, 0xA4);   // 0xa4,Output follows RAM content;0xa5,Output ignores RAM content
     status += ssd1306_WriteCommand(hi2c, 0xD3);   // Set display offset
     status += ssd1306_WriteCommand(hi2c, 0x00);   // No offset
@@ -48,8 +50,14 @@ uint8_t ssd1306_Init(I2C_HandleTypeDef *hi2c)
     status += ssd1306_WriteCommand(hi2c, 0xF0);   // Set divide ratio
     status += ssd1306_WriteCommand(hi2c, 0xD9);   // Set pre-charge period
     status += ssd1306_WriteCommand(hi2c, 0x22);
+
     status += ssd1306_WriteCommand(hi2c, 0xDA);   // Set com pins hardware configuration
-    status += ssd1306_WriteCommand(hi2c, 0x12);
+#ifndef SSD1306_COM_LR_DISABLE_REMAP
+    status += ssd1306_WriteCommand(hi2c, 0x12);   // Enable COM left/right remap
+#else
+    status += ssd1306_WriteCommand(hi2c, 0x02);   // Do not use COM left/right remap
+#endif // SSD1306_COM_LR_REMAP
+
     status += ssd1306_WriteCommand(hi2c, 0xDB);   // Set vcomh
     status += ssd1306_WriteCommand(hi2c, 0x20);   // 0x20,0.77xVcc
     status += ssd1306_WriteCommand(hi2c, 0x8D);   // Set DC-DC enable

--- a/lib/ssd1306.c
+++ b/lib/ssd1306.c
@@ -52,10 +52,10 @@ uint8_t ssd1306_Init(I2C_HandleTypeDef *hi2c)
     status += ssd1306_WriteCommand(hi2c, 0x22);
 
     status += ssd1306_WriteCommand(hi2c, 0xDA);   // Set com pins hardware configuration
-#ifndef SSD1306_COM_LR_DISABLE_REMAP
-    status += ssd1306_WriteCommand(hi2c, 0x12);   // Enable COM left/right remap
+#ifndef SSD1306_COM_LR_REMAP
+    status += ssd1306_WriteCommand(hi2c, 0x32);   // Enable COM left/right remap
 #else
-    status += ssd1306_WriteCommand(hi2c, 0x02);   // Do not use COM left/right remap
+    status += ssd1306_WriteCommand(hi2c, 0x12);   // Do not use COM left/right remap
 #endif // SSD1306_COM_LR_REMAP
 
     status += ssd1306_WriteCommand(hi2c, 0xDB);   // Set vcomh


### PR DESCRIPTION
Add support and documentation for 128x32 oled screens based on the investigation from 
Vavat in #7.