### PR TITLE
Added Option to clear Alternative Pin Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ Some smaller screens might be wired with interlacing, if you encounter issues re
 ```
 make EXTRA_CFLAGS="-DSSD1306_HEIGHT=32 -DSSD1306_COM_LR_REMAP"
 ```
+
+Some screens might also be using another 'Sequential COM pin configuration'. Defining `SSD1306_COM_ALTERNATIVE_PIN_CONFIG` as 0 will configure the controller to use another configuration.
+
+```
+make EXTRA_CFLAGS="-DSSD1306_HEIGHT=32 -DSSD1306_COM_LR_REMAP -DSSD1306_COM_ALTERNATIVE_PIN_CONFIG=0"
+```

--- a/lib/ssd1306.c
+++ b/lib/ssd1306.c
@@ -52,11 +52,7 @@ uint8_t ssd1306_Init(I2C_HandleTypeDef *hi2c)
     status += ssd1306_WriteCommand(hi2c, 0x22);
 
     status += ssd1306_WriteCommand(hi2c, 0xDA);   // Set com pins hardware configuration
-#ifdef SSD1306_COM_LR_REMAP
-    status += ssd1306_WriteCommand(hi2c, 0x32);   // Enable COM left/right remap
-#else
-    status += ssd1306_WriteCommand(hi2c, 0x12);   // Do not use COM left/right remap
-#endif // SSD1306_COM_LR_REMAP
+    status += ssd1306_WriteCommand(hi2c, SSD1306_COM_LR_REMAP << 5 | SSD1306_COM_ALTERNATIVE_PIN_CONFIG << 4 | 0x02);   
 
     status += ssd1306_WriteCommand(hi2c, 0xDB);   // Set vcomh
     status += ssd1306_WriteCommand(hi2c, 0x20);   // 0x20,0.77xVcc
@@ -190,7 +186,7 @@ char ssd1306_WriteChar(char ch, FontDef Font, SSD1306_COLOR color)
 //
 //  Write full string to screenbuffer
 //
-char ssd1306_WriteString(char* str, FontDef Font, SSD1306_COLOR color)
+char ssd1306_WriteString(const char* str, FontDef Font, SSD1306_COLOR color)
 {
     // Write until null-byte
     while (*str)

--- a/lib/ssd1306.h
+++ b/lib/ssd1306.h
@@ -33,6 +33,14 @@
 #define SSD1306_HEIGHT          64
 #endif // SSD1306_HEIGHT
 
+#ifndef SSD1306_COM_LR_REMAP
+#define SSD1306_COM_LR_REMAP    0
+#endif // SSD1306_COM_LR_REMAP
+
+#ifndef SSD1306_COM_ALTERNATIVE_PIN_CONFIG
+#define SSD1306_COM_ALTERNATIVE_PIN_CONFIG    1
+#endif // SSD1306_COM_ALTERNATIVE_PIN_CONFIG
+
 
 //
 //  Enumeration for screen colors
@@ -61,7 +69,7 @@ void ssd1306_UpdateScreen(I2C_HandleTypeDef *hi2c);
 void ssd1306_Fill(SSD1306_COLOR color);
 void ssd1306_DrawPixel(uint8_t x, uint8_t y, SSD1306_COLOR color);
 char ssd1306_WriteChar(char ch, FontDef Font, SSD1306_COLOR color);
-char ssd1306_WriteString(char* str, FontDef Font, SSD1306_COLOR color);
+char ssd1306_WriteString(const char* str, FontDef Font, SSD1306_COLOR color);
 void ssd1306_SetCursor(uint8_t x, uint8_t y);
 void ssd1306_InvertColors(void);
 


### PR DESCRIPTION
I got a 128x32 pixel Oled Display from Amazon, that didnt work with this library.
I figured out, that i had to clear the Alternative Pin Function Bit when using the Set COM Pins Hardware Configuration. (Page 31 in the [Datasheet](https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf)). 

I added an option to do so and also added a short example at the end of the Readme.

Additionally i changed the signature of `char ssd1306_WriteString(char* str, FontDef Font, SSD1306_COLOR color);` to `char ssd1306_WriteString(const char* str, FontDef Font, SSD1306_COLOR color);`, because it doesnt change the data str is pointing to.