### PR TITLE
Add ssd1306_WriteBitmap

### DIFF
--- a/lib/ssd1306.c
+++ b/lib/ssd1306.c
@@ -206,6 +206,34 @@ char ssd1306_WriteString(const char* str, FontDef Font, SSD1306_COLOR color)
 }
 
 //
+//  Draw bitmap to the screen buffer
+//  bmp      => bitmap (128x64) to write
+//
+//  color   => Black or White
+//
+void ssd1306_WriteBitmap(uint8_t *bmp, SSD1306_COLOR color)
+{
+    uint8_t i,j, k;
+
+
+
+    // Translate font to screenbuffer
+    for (i = 0; i < SSD1306_HEIGHT; i++)
+    {
+
+    	for (j = 0; j < SSD1306_WIDTH/8; j++)
+        {
+        	for (k=0;k<8;k++){
+				if ((         *(bmp+SSD1306_WIDTH/8*i+j)      << k) & 0x80){ssd1306_DrawPixel( j*8+k , i , (SSD1306_COLOR) color);}
+
+				else{ssd1306_DrawPixel( j*8+k , i , (SSD1306_COLOR)!color);}
+        	}
+        }
+    }
+
+}
+
+//
 //  Invert background/foreground colors
 //
 void ssd1306_InvertColors(void)

--- a/lib/ssd1306.h
+++ b/lib/ssd1306.h
@@ -70,6 +70,7 @@ void ssd1306_Fill(SSD1306_COLOR color);
 void ssd1306_DrawPixel(uint8_t x, uint8_t y, SSD1306_COLOR color);
 char ssd1306_WriteChar(char ch, FontDef Font, SSD1306_COLOR color);
 char ssd1306_WriteString(const char* str, FontDef Font, SSD1306_COLOR color);
+void ssd1306_WriteBitmap(uint8_t *bmp, SSD1306_COLOR color);
 void ssd1306_SetCursor(uint8_t x, uint8_t y);
 void ssd1306_InvertColors(void);
 


### PR DESCRIPTION
This function allow us to draw a bitmap of size 128*64
The bitmap should be an array of uint8_t of length 128*64/8 , the value of the pixels are in the uint8_t in binary form. The array should be written from top left of the image to bottom right.
Example : uint8_t image[] = {0x15,0x16 .................................... 0x00,0xFF}